### PR TITLE
Pagination on containers

### DIFF
--- a/swiftbrowser/settings.py
+++ b/swiftbrowser/settings.py
@@ -42,3 +42,7 @@ SECRET_KEY = 'DONT_USE_THIS_IN_PRODUCTION'
 STATIC_URL = "http://cdnjs.cloudflare.com/ajax/libs/"
 
 ALLOWED_HOSTS = ['127.0.0.1', 'insert_your_hostname_here']
+
+SWIFT_BROWSER_SETTINGS = {
+    "containers_per_page" : 5
+}

--- a/swiftbrowser/templates/containerview.html
+++ b/swiftbrowser/templates/containerview.html
@@ -7,10 +7,10 @@
     {% include "messages.html" %}
         <ul class="breadcrumb">
             <li><a href="{% url "containerview" %}">Containers</a></li>
-       </ul> 
-    
+       </ul>
+
         <table class="table table-striped">
-        
+
         <thead>
             <tr>
                 <th style="width: 1em;" class="hidden-phone"></th>
@@ -20,7 +20,7 @@
                 <th style="width: 1em;">
 
                 <a href="{% url "create_container" %}" class="btn btn-mini btn-danger">
-                    <i class="icon-plus icon-white"></i> 
+                    <i class="icon-plus icon-white"></i>
                 </a>
 
                 </th>
@@ -43,7 +43,7 @@
                             <li><a href="{{ edit_acl_url }}"><i class="icon-user"></i> {% trans 'Sharing' %}</a></li>
                             <li class="divider" />
                         {% endif %}
- 
+
                         <li>
                             <a href="{% url "delete_container" container=container.name %}" onclick="return confirm('{% trans 'Delete container' %} {{container.name}}?');">
                                 <i class="icon-trash"></i> {% trans 'Delete container' %}
@@ -53,31 +53,50 @@
                 </div>
             </td>
 
-            </tr> 
+            </tr>
 
         {% empty %}
         <tr>
             <td colspan="5">
             <strong><center>{% trans 'There are no containers in this account yet. Create a new container by clicking the red button.' %}<center></strong>
             </td>
-        </tr> 
- 
+        </tr>
+
         {% endfor %}
-        </tbody> 
-       
+        </tbody>
+
         <tfoot>
             <tr>
                 <th colspan="5" class="center">
-                    {{account_stat.x_account_bytes_used|filesizeformat}} 
+                    {{account_stat.x_account_bytes_used|filesizeformat}}
                     {% if account_stat.x_account_meta_quota_bytes %}
                         {% trans 'of' %}
-                        {{account_stat.x_account_meta_quota_bytes|filesizeformat}} 
+                        {{account_stat.x_account_meta_quota_bytes|filesizeformat}}
                     {% endif %}
                     {% trans 'used' %}
                 </th>
             </tr>
         </tfoot>
         </table>
+        <nav class="pagination">
+            <form method="POST" action="/" class="form-horizontal">
+                {% csrf_token %}
+
+                <ul class="pager">
+                    <li>
+                        <a href="#">
+                            <input type="submit" name="get_previous" value="Previous"/>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#">
+                            <input type="submit" name="get_next" value="Next"/>
+                        </a>
+                    </li>
+                </ul>
+
+            </form>
+        </nav>
         </div>
         </div>
     {% endblock %}

--- a/swiftbrowser/views.py
+++ b/swiftbrowser/views.py
@@ -53,10 +53,59 @@ def containerview(request):
     storage_url = request.session.get('storage_url', '')
     auth_token = request.session.get('auth_token', '')
 
+    # "markers" is a list used to keep track of container names for pagination.
+    if "markers" not in request.session:
+
+        # The initial marker with an empty string.
+        request.session["markers"] = ['']
+    marker = ""
+
+    if("get_next" in request.POST):
+
+        # If requesting the next page, and there are none,
+        # the marker should be the last not None marker.
+        if request.session["markers"][-1] is None:
+            request.session["markers"].pop()
+
+        # Use the latest marker to get the next page.
+        marker = request.session["markers"][-1]
+
+    elif ("get_previous" in request.POST):
+
+        # Remove the "next" marker
+        request.session["markers"].pop()
+
+        # Remove the "current" marker if we're not at the very beginning.
+        if len(request.session["markers"]) != 1:
+            request.session["markers"].pop()
+
+        # Use the "previous" marker
+        marker = request.session["markers"][-1]
+
+    else:
+        # Reset marker stack.
+        request.session["markers"] = ['']
+        marker = ""
+
     try:
-        account_stat, containers = client.get_account(storage_url, auth_token)
+        account_stat, containers = client.get_account(
+            storage_url,
+            auth_token,
+            marker,
+            settings.SWIFT_BROWSER_SETTINGS["containers_per_page"])
     except client.ClientException:
         return redirect(login)
+
+    # Add the last result to the markers list.
+    if len(containers) == 5:
+        new_marker = containers[-1]["name"]
+    else:
+        new_marker = None
+
+    request.session["markers"].append(new_marker)
+
+    # Save the session
+    request.session.modified = True
 
     account_stat = replace_hyphens(account_stat)
 


### PR DESCRIPTION
The following changes add pagination among containers. It is achieved by using a basic form and POST. The backend keeps track of what "marker" the user is at with a list stored in the session. This marker is used in swiftclient.client.get_account's marker paramter (http://docs.openstack.org/developer/python-swiftclient/swiftclient.html#swiftclient.client.get_account) to get containers starting from after the marker.

Some potential changes to this arrangement include:
-Moving the logic from views.py:containerview() to a model?
-Replacing the form post with ajax

A known bug:
-After a user clicks "get next", loads the page, and then refreshes, the next page will load instead of refreshing the current page. This can be fixed by using ajax instead of form/post.

Please let me know your thoughts, I am completely open to any changes to get this patch landed.

Thank you,

Peter

PS The gif below is weird and flashy in the first few seconds but then it calms down and you can see the demo.
![pagination-demo](https://cloud.githubusercontent.com/assets/1406343/6899917/52daf292-d6d1-11e4-9caf-9d1ee4fcf080.gif)

Peter
