### PR TITLE
Add python-keystoneclient to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     url='https://github.com/cschwede/django-swiftbrowser',
     author='Christian Schwede',
     author_email='info@cschwede.de',
-    install_requires=['django>=1.5', 'python-swiftclient'],
+    install_requires=['django>=1.5', 'python-swiftclient',
+                      'python-keystoneclient'],
     zip_safe=False,
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
`python-keystoneclient` is needed for keystone authentication