### PR TITLE
prevent installation of django 1.10 (not backward compatible)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/cschwede/django-swiftbrowser',
     author='Christian Schwede',
     author_email='info@cschwede.de',
-    install_requires=['django>=1.5', 'python-swiftclient'],
+    install_requires=['django>=1.5,<=1.9', 'python-swiftclient'],
     zip_safe=False,
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
If django 1.10 is selected for installation, than the routes are not valid (the urlpatterns scheme used here is not compatible with 1.10).